### PR TITLE
Adding the interface MiniMeTokenI

### DIFF
--- a/contracts/Contribution.sol
+++ b/contracts/Contribution.sol
@@ -3,9 +3,7 @@ pragma solidity ^0.4.11;
 import "./misc/SafeMath.sol";
 import "./interface/Controlled.sol";
 import "./interface/TokenController.sol";
-import "./SIT.sol";
-import "./MSP.sol";
-
+import "./interface/MiniMeTokenI.sol";
 
 /*
   Copyright 2017, Anton Egorov (Mothership Foundation)
@@ -37,8 +35,9 @@ contract Contribution is Controlled, TokenController {
   uint256 public totalSupplyCap;
   uint256 public exchangeRate;
 
-  MiniMeToken public SIT;
-  MiniMeToken public MSP;
+  MiniMeTokenI public sit;
+  MiniMeTokenI public msp;
+
   uint256 public startBlock;
   uint256 public endBlock;
 
@@ -56,7 +55,7 @@ contract Contribution is Controlled, TokenController {
   bool public paused;
 
   modifier initialized() {
-    require(address(MSP) != 0x0);
+    require(address(msp) != 0x0);
     _;
   }
 
@@ -64,7 +63,7 @@ contract Contribution is Controlled, TokenController {
     require(getBlockNumber() >= startBlock &&
             getBlockNumber() <= endBlock &&
             finalizedBlock == 0 &&
-            address(MSP) != 0x0);
+            address(msp) != 0x0);
     _;
   }
 
@@ -74,6 +73,7 @@ contract Contribution is Controlled, TokenController {
   }
 
   function Contribution() {
+    // Booleans are false by default consider removing this
     paused = false;
   }
 
@@ -108,12 +108,12 @@ contract Contribution is Controlled, TokenController {
       address _sit
   ) public onlyController {
     // Initialize only once
-    require(address(MSP) == 0x0);
+    require(address(msp) == 0x0);
 
-    MSP = MiniMeToken(_msp);
-    require(MSP.totalSupply() == 0);
-    require(MSP.controller() == address(this));
-    require(MSP.decimals() == 18);  // Same amount of decimals as ETH
+    msp = MiniMeTokenI(_msp);
+    require(msp.totalSupply() == 0);
+    require(msp.controller() == address(this));
+    require(msp.decimals() == 18);  // Same amount of decimals as ETH
 
     require(_mspController != 0x0);
     mspController = _mspController;
@@ -136,10 +136,10 @@ contract Contribution is Controlled, TokenController {
     destTokensTeam = _destTokensTeam;
 
     require(_sit != 0x0);
-    SIT = MiniMeToken(_sit);
+    sit = MiniMeTokenI(_sit);
 
     // SIT amount should be no more than 20% of MSP total supply cap
-    require(MiniMeToken(SIT).totalSupply() * 5 <= _totalSupplyCap);
+    require(MiniMeTokenI(sit).totalSupply() * 5 <= _totalSupplyCap);
     totalSupplyCap = _totalSupplyCap;
   }
 
@@ -177,7 +177,7 @@ contract Contribution is Controlled, TokenController {
 
     // Antispam mechanism
     address caller;
-    if (msg.sender == address(MSP)) {
+    if (msg.sender == address(msp)) {
       caller = _th;
     } else {
       caller = msg.sender;
@@ -194,13 +194,13 @@ contract Contribution is Controlled, TokenController {
       uint256 tokensGenerated = toFund.mul(exchangeRate);
 
       // Check total supply cap reached
-      uint256 newTotalSupply = tokensGenerated.add(MSP.totalSupply());
+      uint256 newTotalSupply = tokensGenerated.add(msp.totalSupply());
       if (newTotalSupply > totalSupplyCap) {
         tokensGenerated = tokensGenerated.sub(newTotalSupply.sub(totalSupplyCap));
         toFund = tokensGenerated.div(exchangeRate);
       }
 
-      assert(MSP.generateTokens(_th, tokensGenerated));
+      assert(msp.generateTokens(_th, tokensGenerated));
       destEthDevs.transfer(toFund);
       NewSale(_th, toFund, tokensGenerated);
     }
@@ -210,7 +210,7 @@ contract Contribution is Controlled, TokenController {
       // If the call comes from the Token controller,
       // then we return it to the token Holder.
       // Otherwise we return to the sender.
-      if (msg.sender == address(MSP)) {
+      if (msg.sender == address(msp)) {
         _th.transfer(toReturn);
       } else {
         msg.sender.transfer(toReturn);
@@ -237,7 +237,7 @@ contract Contribution is Controlled, TokenController {
 
   /// @return Total tokens issued in weis.
   function tokensIssued() public constant returns (uint256) {
-    return MSP.totalSupply();
+    return msp.totalSupply();
   }
 
 
@@ -260,8 +260,8 @@ contract Contribution is Controlled, TokenController {
   /// @param _token The address of the token contract that you want to recover
   ///  set to 0 in case you want to extract ether.
   function claimTokens(address _token) public onlyController {
-    if (MSP.controller() == address(this)) {
-      MSP.claimTokens(_token);
+    if (msp.controller() == address(this)) {
+      msp.claimTokens(_token);
     }
     if (_token == 0x0) {
       controller.transfer(this.balance);

--- a/contracts/MSPPlaceholder.sol
+++ b/contracts/MSPPlaceholder.sol
@@ -29,16 +29,18 @@ pragma solidity ^0.4.11;
 
 import "./misc/SafeMath.sol";
 import "./interface/Controlled.sol";
+import "./interface/TokenController.sol";
 import "./interface/ERC20Token.sol";
-import "./MiniMeToken.sol";
+import "./interface/MiniMeTokenI.sol";
 import "./Contribution.sol";
 
 
 contract MSPPlaceHolder is Controlled, TokenController {
   using SafeMath for uint256;
 
-  MiniMeToken public msp;
+  MiniMeTokenI public msp;
   Contribution public contribution;
+
   uint256 public activationTime;
   address public sitExchanger;
 
@@ -50,7 +52,7 @@ contract MSPPlaceHolder is Controlled, TokenController {
   ///  only this exchanger will be able to move tokens)
   function MSPPlaceHolder(address _controller, address _msp, address _contribution, address _sitExchanger) {
     controller = _controller;
-    msp = MiniMeToken(_msp);
+    msp = MiniMeTokenI(_msp);
     contribution = Contribution(_contribution);
     sitExchanger = _sitExchanger;
   }
@@ -100,7 +102,7 @@ contract MSPPlaceHolder is Controlled, TokenController {
   // Testing specific methods
   //////////
 
-  /// @notice This function is overrided by the test Mocks.
+  /// @notice This function is overridden by the test Mocks.
   function getTime() internal returns (uint256) {
     return now;
   }

--- a/contracts/MiniMeToken.sol
+++ b/contracts/MiniMeToken.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.4.11;
 
 import "./interface/ERC20Token.sol";
+import "./interface/MiniMeTokenI.sol";
 import "./interface/TokenController.sol";
-import "./interface/Controlled.sol";
 import "./interface/ApproveAndCallReceiver.sol";
 
 /*
@@ -24,13 +24,7 @@ import "./interface/ApproveAndCallReceiver.sol";
 /// @dev The actual token contract, the default controller is the msg.sender
 ///  that deploys the contract, so usually this token will be deployed by a
 ///  token controller contract, which Giveth will call a "Campaign"
-contract MiniMeToken is Controlled {
-
-    string public name;                //The Token's name: e.g. DigixDAO Tokens
-    uint8 public decimals;             //Number of decimals of the smallest unit
-    string public symbol;              //An identifier: e.g. REP
-    string public version = 'MMT_0.1'; //An arbitrary versioning scheme
-
+contract MiniMeToken is MiniMeTokenI {
 
     /// @dev `Checkpoint` is the structure that attaches a block number to a
     ///  given value, the block number attached is the one that last changed the

--- a/contracts/SITExchanger.sol
+++ b/contracts/SITExchanger.sol
@@ -30,7 +30,7 @@ pragma solidity ^0.4.11;
 import "./misc/SafeMath.sol";
 import "./interface/Controlled.sol";
 import "./interface/ERC20Token.sol";
-import "./MiniMeToken.sol";
+import "./interface/MiniMeTokenI.sol";
 import "./Contribution.sol";
 
 contract SITExchanger is Controlled, TokenController {
@@ -38,13 +38,13 @@ contract SITExchanger is Controlled, TokenController {
 
   mapping (address => uint256) public collected;
   uint256 public totalCollected;
-  MiniMeToken public sit;
-  MiniMeToken public msp;
+  MiniMeTokenI public sit;
+  MiniMeTokenI public msp;
   Contribution public contribution;
 
   function SITExchanger(address _sit, address _msp, address _contribution) {
-    sit = MiniMeToken(_sit);
-    msp = MiniMeToken(_msp);
+    sit = MiniMeTokenI(_sit);
+    msp = MiniMeTokenI(_msp);
     contribution = Contribution(_contribution);
   }
 

--- a/contracts/interface/ERC20Token.sol
+++ b/contracts/interface/ERC20Token.sol
@@ -20,7 +20,7 @@ contract ERC20Token {
      function by the compiler.
   */
   /// total amount of tokens
-  uint256 public totalSupply;
+  function totalSupply() constant returns (uint256 balance);
 
   /// @param _owner The address from which the balance will be retrieved
   /// @return The balance

--- a/contracts/interface/MiniMeTokenI.sol
+++ b/contracts/interface/MiniMeTokenI.sol
@@ -1,0 +1,112 @@
+pragma solidity ^0.4.11;
+
+import "./ERC20Token.sol";
+import "./Controlled.sol";
+
+contract MiniMeTokenI is ERC20Token, Controlled {
+
+      string public name;                //The Token's name: e.g. DigixDAO Tokens
+      uint8 public decimals;             //Number of decimals of the smallest unit
+      string public symbol;              //An identifier: e.g. REP
+      string public version = 'MMT_0.1'; //An arbitrary versioning scheme
+
+///////////////////
+// ERC20 Methods
+///////////////////
+
+
+    /// @notice `msg.sender` approves `_spender` to send `_amount` tokens on
+    ///  its behalf, and then a function is triggered in the contract that is
+    ///  being approved, `_spender`. This allows users to use their tokens to
+    ///  interact with contracts in one function call instead of two
+    /// @param _spender The address of the contract able to transfer the tokens
+    /// @param _amount The amount of tokens to be approved for transfer
+    /// @return True if the function call was successful
+    function approveAndCall(
+        address _spender,
+        uint256 _amount,
+        bytes _extraData
+    ) returns (bool success);
+
+////////////////
+// Query balance and totalSupply in History
+////////////////
+
+    /// @dev Queries the balance of `_owner` at a specific `_blockNumber`
+    /// @param _owner The address from which the balance will be retrieved
+    /// @param _blockNumber The block number when the balance is queried
+    /// @return The balance at `_blockNumber`
+    function balanceOfAt(
+        address _owner,
+        uint _blockNumber
+    ) constant returns (uint);
+
+    /// @notice Total amount of tokens at a specific `_blockNumber`.
+    /// @param _blockNumber The block number when the totalSupply is queried
+    /// @return The total amount of tokens at `_blockNumber`
+    function totalSupplyAt(uint _blockNumber) constant returns(uint);
+
+////////////////
+// Clone Token Method
+////////////////
+
+    /// @notice Creates a new clone token with the initial distribution being
+    ///  this token at `_snapshotBlock`
+    /// @param _cloneTokenName Name of the clone token
+    /// @param _cloneDecimalUnits Number of decimals of the smallest unit
+    /// @param _cloneTokenSymbol Symbol of the clone token
+    /// @param _snapshotBlock Block when the distribution of the parent token is
+    ///  copied to set the initial distribution of the new clone token;
+    ///  if the block is zero than the actual block, the current block is used
+    /// @param _transfersEnabled True if transfers are allowed in the clone
+    /// @return The address of the new MiniMeToken Contract
+    function createCloneToken(
+        string _cloneTokenName,
+        uint8 _cloneDecimalUnits,
+        string _cloneTokenSymbol,
+        uint _snapshotBlock,
+        bool _transfersEnabled
+    ) returns(address);
+
+////////////////
+// Generate and destroy tokens
+////////////////
+
+    /// @notice Generates `_amount` tokens that are assigned to `_owner`
+    /// @param _owner The address that will be assigned the new tokens
+    /// @param _amount The quantity of tokens generated
+    /// @return True if the tokens are generated correctly
+    function generateTokens(address _owner, uint _amount) returns (bool);
+
+
+    /// @notice Burns `_amount` tokens from `_owner`
+    /// @param _owner The address that will lose the tokens
+    /// @param _amount The quantity of tokens to burn
+    /// @return True if the tokens are burned correctly
+    function destroyTokens(address _owner, uint _amount) returns (bool);
+
+////////////////
+// Enable tokens transfers
+////////////////
+
+    /// @notice Enables token holders to transfer their tokens freely if true
+    /// @param _transfersEnabled True if transfers are allowed in the clone
+    function enableTransfers(bool _transfersEnabled);
+
+//////////
+// Safety Methods
+//////////
+
+    /// @notice This method can be used by the controller to extract mistakenly
+    ///  sent tokens to this contract.
+    /// @param _token The address of the token contract that you want to recover
+    ///  set to 0 in case you want to extract ether.
+    function claimTokens(address _token);
+
+////////////////
+// Events
+////////////////
+
+    event ClaimedTokens(address indexed _token, address indexed _controller, uint _amount);
+    event NewCloneToken(address indexed _cloneToken, uint _snapshotBlock);
+}


### PR DESCRIPTION
This interface has all of the public functions (also the public variables) from MiniMeToken.
Contracts on the system, referencing SIT or MSP will instead import MiniMeTokenI. This way the deployment code will be much slimmer (using less gas) and will run faster on loading.

# Caveats:
  - Updating the MinimeToken source code will require a quick double check in case a function signature changed or a function is removed or added although that would be rather unlikely.